### PR TITLE
Clarifying that Consultants cannot be practitioners

### DIFF
--- a/practitioner_definition.md
+++ b/practitioner_definition.md
@@ -2,6 +2,6 @@
 
 This file outlines the criteria for joining the FinOps Foundation as a Practitioner member.
 
-> Practitioners must: (i) be actively working in FinOps: (a) in an executive capacity, such as a Chief Information Officer or Chief Technology Officer; (b) in IT/engineering and operations; (c) in finance and/or procurement; (d) as a FinOps practitioner; or (e) in a similar capacity (regardless of title); (ii) not be employed by a FinOps, cloud, or cloud management vendor; and (iii) not have FinOps-related sales, marketing, or business development as their primary business. 
+> Practitioners must: (i) be actively working in FinOps or cloud financial management related work: (a) in an executive capacity, such as a Chief Information Officer or Chief Technology Officer; (b) in IT/engineering and operations; (c) in finance and/or procurement; (d) as a FinOps practitioner; or (e) in a similar capacity (regardless of title); (ii) not be employed by a FinOps, cloud, or cloud management vendor or company offering consultancy or advisory services; and (iii) not have FinOps-related sales, marketing, or business development as their primary business, regardless of the company they are in. 
 
 This definition is owned by the Technical Advisory Council and may evolve over time.


### PR DESCRIPTION
The definition of consultants / vendors is ambiguous, aiming to clarify it for membership purposes.